### PR TITLE
get status of video driver

### DIFF
--- a/query.go
+++ b/query.go
@@ -80,6 +80,18 @@ func GetNamedVideoSource(
 	return newVideoSourceFromDriver(d, selectedMedia, logger)
 }
 
+func GetStatusVideoSource(
+	name string,
+	constraints mediadevices.MediaStreamConstraints,
+	logger golog.Logger,
+) (driver.State, error) {
+	d, _, err := getUserVideoDriver(constraints, &name, logger)
+	if err != nil {
+		return driver.StateClosed, err
+	}
+	return d.Status(), nil
+}
+
 // GetPatternedVideoSource attempts to find a video device (not a screen) by the given label pattern.
 func GetPatternedVideoSource(
 	labelPattern *regexp.Regexp,


### PR DESCRIPTION
This commit is to help resolve [DATA-764](https://viam.atlassian.net/browse/DATA-764). The PR for that is https://github.com/viamrobotics/rdk/pull/1595. We need to monitor the status of the video driver to ensure we free resources after a webcam is unplug. See the Jira ticket for more info and steps to reproduce.